### PR TITLE
Add Bluetooth componetent 

### DIFF
--- a/components/ble_proxy.yaml
+++ b/components/ble_proxy.yaml
@@ -1,0 +1,2 @@
+bluetooth_proxy:
+  active: true

--- a/components/ble_tracker.yaml
+++ b/components/ble_tracker.yaml
@@ -1,0 +1,5 @@
+esp32_ble_tracker:
+  scan_parameters:
+    interval: 1100ms
+    window: 1100ms
+    active: true

--- a/guition-35-example.yaml
+++ b/guition-35-example.yaml
@@ -9,3 +9,7 @@ packages:
   common: !include common.yaml
   device: !include devices/JC3248W535.yaml
   layout: !include layouts/480x320.yaml
+  # enable Bluetooth tracker and Proxy
+  # from the components folder
+  ble_tracker: !include components/ble_tracker.yaml
+  ble_proxy: !include components/ble_proxy.yaml


### PR DESCRIPTION
This PR shall enable Bluetooth proxy and Bluetooth tracker.

Unfortunately the change crashes my guition-35 atm I need to debug why. Building esphome outside this project with this two components works well. 

Thanks for you amazing work!